### PR TITLE
 Use `action='append'` instead of `nargs='+'` for the -o option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ Copy of `compileall` module from CPython source code with some new features, nam
 * `-s` and `-a` command line options for manipulation of the path baked into
   a compiled `*.pyc` file.
 
-* `-o` command line option enables you to specify multiple optimization levels
-  at once which leads to multiple byte-compiled files (for each optimization level)
-  in one run
+* the `-o` command line option can be specified multiple times to compile for 
+  multiple optimization levels in one run
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Copy of `compileall` module from CPython source code with some new features, nam
 
 * default recursion limit is now "unlimited" (actually limited by `sys.getrecursionlimit()`)
 
-* `-s` and `-a` command line options for manipulation with path baked into
+* `-s` and `-a` command line options for manipulation of the path baked into
   a compiled `*.pyc` file.
 
 * `-o` command line option enables you to specify multiple optimization levels
@@ -26,17 +26,20 @@ Copy of `compileall` module from CPython source code with some new features, nam
 Example usage:
 
 ```shell
-# Create some script with bad syntax
+# Create some script (this one raises an exception to show tracebacks)
 $ echo "1 / 0" > test.py
+
 # Compile it
 $ compileall2 test.py 
 Compiling 'test.py'...
+
 # Try to execute compiled version directly
 $ python __pycache__/test.cpython-37.pyc 
 Traceback (most recent call last):
   File "test.py", line 1, in <module>
     1 / 0
 ZeroDivisionError: division by zero
+
 # Recompile it with changes path which will be visible in error message
 $ compileall2 -f -a /foo/bar test.py 
 Compiling 'test.py'...
@@ -44,6 +47,7 @@ $ python __pycache__/test.cpython-37.pyc
 Traceback (most recent call last):
   File "/foo/bar/test.py", line 1, in <module>
 ZeroDivisionError: division by zero
+
 # Same thing as above but executed as a Python module
 $ python -m compileall2 -f -a /bar/baz test.py 
 Compiling 'test.py'...

--- a/compileall2.py
+++ b/compileall2.py
@@ -352,8 +352,7 @@ def main():
                               'to the equivalent of -l sys.path'))
     parser.add_argument('-j', '--workers', default=1,
                         type=int, help='Run compileall concurrently')
-    parser.add_argument('-o', nargs='+', type=int, dest='opt_levels',
-                        default=-1,
+    parser.add_argument('-o', action='append', type=int, dest='opt_levels',
                         help=('Optimization levels to run compilation with.'
                               'Default is -1 which uses optimization level of'
                               'Python interpreter itself (specified by -O).'))
@@ -380,6 +379,9 @@ def main():
         maxlevels = args.recursion
     else:
         maxlevels = args.maxlevels
+
+    if args.opt_levels is None:
+        args.opt_levels = [-1]
 
     # if flist is provided then load it
     if args.flist:

--- a/test_compileall_original.py
+++ b/test_compileall_original.py
@@ -812,7 +812,7 @@ class CommandLineTestsBase:
                              ["0", "2"],
                              ["0", "1", "2"]]
         for opt_combination in test_combinations:
-            self.assertRunOK(path, "-o", *opt_combination)
+            self.assertRunOK(path, *("-o" + str(n) for n in opt_combination))
             for opt_level in opt_combination:
                 self.assertTrue(os.path.isfile(bc[int(opt_level)]))
                 try:


### PR DESCRIPTION
Here's a suggestion: instead of `-o 0 1 2`, users should use `-o 0 -o 1 -o 2`. It's more to type, but much more explicit.